### PR TITLE
Harshn08 licence typo

### DIFF
--- a/MultinodeScript/roles/cdpdc_cm_server/tasks/main.yml
+++ b/MultinodeScript/roles/cdpdc_cm_server/tasks/main.yml
@@ -113,7 +113,7 @@
 
 # LICENSE
 # if fresh install, api returns a 404 
-- name: Trial Licence
+- name: Trial License
   block:
     - name: get License details
       uri:

--- a/MultinodeScript/roles/cdpdc_cm_server/tasks/main.yml
+++ b/MultinodeScript/roles/cdpdc_cm_server/tasks/main.yml
@@ -135,13 +135,13 @@
           - 204
         method: POST
       when: _license.json.message is defined
-  when: cdpdc.cm.licence.type == "trial"
+  when: cdpdc.cm.license.type == "trial"
 
 - name: Enterprise license
   block:
     - name: upload lic file to host
       copy:
-        src: "{{ cdpdc.cm.licence.filepath }}"
+        src: "{{ cdpdc.cm.license.filepath }}"
         dest: /root/lic.txt
         owner: root
         group: root
@@ -158,7 +158,7 @@
         warn: False
       register: resp
       failed_when: "'owner' not in resp.stdout"
-  when: cdpdc.cm.licence.type == "enterprise"
+  when: cdpdc.cm.license.type == "enterprise"
 
 
 


### PR DESCRIPTION
fixed the typo on line 116, 138, 144 and 161 from "licence" to "license" in /roles/cdpdc_cm_server/tasks/main.yml file